### PR TITLE
Added support for logger.debug

### DIFF
--- a/src/__tests__/logger.test.js
+++ b/src/__tests__/logger.test.js
@@ -21,11 +21,12 @@ var ieVersion = parseInt((/msie (\d+)/.exec(navigator.userAgent.toLowerCase()) |
 var launchPrefix = ieVersion === 10 ? '[Launch]' : ROCKET;
 
 describe('logger', function() {
-  var STANDARD_LOG_METHODS = ['log', 'info', 'warn', 'error'];
+  var STANDARD_LOG_METHODS = ['log', 'info', 'debug', 'warn', 'error'];
 
   beforeEach(function() {
     spyOn(window.console, 'log');
     spyOn(window.console, 'info');
+    spyOn(window.console, 'debug');
     spyOn(window.console, 'warn');
     spyOn(window.console, 'error');
   });

--- a/src/logger.js
+++ b/src/logger.js
@@ -19,6 +19,7 @@
 var levels = {
   LOG: 'log',
   INFO: 'info',
+  DEBUG: 'debug',
   WARN: 'warn',
   ERROR: 'error'
 };
@@ -58,6 +59,9 @@ var process = function(level) {
   if (outputEnabled && window.console) {
     var logArguments = Array.prototype.slice.call(arguments, 1);
     logArguments.unshift(launchPrefix);
+    if (level === levels.DEBUG && !window.console[level]) {
+      level = levels.INFO;
+    }
     window.console[level].apply(window.console, logArguments);
   }
 };
@@ -76,6 +80,13 @@ var log = process.bind(null, levels.LOG);
 var info = process.bind(null, levels.INFO);
 
 /**
+ * Outputs debug message to the web console. In browsers that do not support
+ * console.debug, console.info is used instead.
+ * @param {...*} arg Any argument to be logged.
+ */
+var debug = process.bind(null, levels.DEBUG);
+
+/**
  * Outputs a warning message to the web console.
  * @param {...*} arg Any argument to be logged.
  */
@@ -90,6 +101,7 @@ var error = process.bind(null, levels.ERROR);
 module.exports = {
   log: log,
   info: info,
+  debug: debug,
   warn: warn,
   error: error,
   /**
@@ -112,6 +124,7 @@ module.exports = {
     return {
       log: log.bind(null, loggerSpecificPrefix),
       info: info.bind(null, loggerSpecificPrefix),
+      debug: debug.bind(null, loggerSpecificPrefix),
       warn: warn.bind(null, loggerSpecificPrefix),
       error: error.bind(null, loggerSpecificPrefix)
     };


### PR DESCRIPTION
This adds support for console.debug (via turbine.logger.debug & _satellite.logger.debug) for all browsers that support it. 

Browser support is determined by the presence of the `debug` method on the console object.  
    if (level === levels.DEBUG && !window.console[level]) {
      level = levels.INFO;
    }

If the `debug` method does not exist, the log level is upgraded from `debug` to `info`.