### PR TITLE
Update promise-polyfill dependency to 8.1.3

### DIFF
--- a/coreModulePackages/loadScript/package-lock.json
+++ b/coreModulePackages/loadScript/package-lock.json
@@ -9,12 +9,12 @@
       "resolved": "https://registry.npmjs.org/@adobe/reactor-promise/-/reactor-promise-1.0.0.tgz",
       "integrity": "sha512-SCK/JLUd7UhwXQvyYRB8B8zvpk2aW8aGf3Xx8dZVXiaHrULgcWfVB5IzpbTsdwbez2HmsVteT7L7xIS2PZW87A==",
       "requires": {
-        "promise-polyfill": "6.0.2"
+        "promise-polyfill": "8.1.3"
       }
     },
     "promise-polyfill": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
       "integrity": "sha1-2chtPcTcLfkBboiUbe/Wm0m0EWI="
     }
   }

--- a/coreModulePackages/promise/package-lock.json
+++ b/coreModulePackages/promise/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "promise-polyfill": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.0.2.tgz",
-      "integrity": "sha1-2chtPcTcLfkBboiUbe/Wm0m0EWI="
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g=="
     }
   }
 }

--- a/coreModulePackages/promise/package.json
+++ b/coreModulePackages/promise/package.json
@@ -13,6 +13,6 @@
     "url": "git@github.com:Adobe-Marketing-Cloud/reactor-turbine.git"
   },
   "dependencies": {
-    "promise-polyfill": "6.0.2"
+    "promise-polyfill": "8.1.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
       "resolved": "https://registry.npmjs.org/@adobe/reactor-promise/-/reactor-promise-1.0.0.tgz",
       "integrity": "sha512-SCK/JLUd7UhwXQvyYRB8B8zvpk2aW8aGf3Xx8dZVXiaHrULgcWfVB5IzpbTsdwbez2HmsVteT7L7xIS2PZW87A==",
       "requires": {
-        "promise-polyfill": "6.0.2"
+        "promise-polyfill": "8.1.3"
       }
     },
     "@adobe/reactor-query-string": {
@@ -2820,8 +2820,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2842,14 +2841,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2864,20 +2861,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2994,8 +2988,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3007,7 +3000,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3022,7 +3014,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3030,14 +3021,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3056,7 +3045,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3137,8 +3125,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3150,7 +3137,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3236,8 +3222,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3273,7 +3258,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3293,7 +3277,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3337,14 +3320,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5441,8 +5422,8 @@
       "dev": true
     },
     "promise-polyfill": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.0.2.tgz",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
       "integrity": "sha1-2chtPcTcLfkBboiUbe/Wm0m0EWI="
     },
     "prr": {


### PR DESCRIPTION
Due to the requirements of some clients requiring updated dependencies, this PR simply updates the promise-polyfill dependency to 8.1.3