### PR TITLE
Check if window object exists. It doesn't exist in all environments.

### DIFF
--- a/coreModulePackages/promise/index.js
+++ b/coreModulePackages/promise/index.js
@@ -16,6 +16,7 @@
 // with Webpack 2+. We need `require('promise-polyfill').default` for running the tests
 // and `require('promise-polyfill')` for building Turbine.
 module.exports =
-  window.Promise ||
+  (typeof window !== 'undefined' && window.Promise) ||
+  (typeof global !== 'undefined' && global.Promise) ||
   require('promise-polyfill').default ||
   require('promise-polyfill');


### PR DESCRIPTION
We will run code using the '@adobe/reactor-promise` package on other environments than the browser. Other environments won't have the `window` object. This commit makes the check more secure.