### PR TITLE
fix(package): The repository has moved URL

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,55 @@
+<!-- Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+
+<!--- Describe your changes in detail -->
+
+## Related Issue
+
+<!--- This project only accepts pull requests related to open issues -->
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
+<!--- Please link to the issue here: -->
+
+## Motivation and Context
+
+<!--- Why is this change required? What problem does it solve? -->
+
+## How Has This Been Tested?
+
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Screenshots (if appropriate):
+
+## Types of changes
+
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist:
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+
+- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have read the **CONTRIBUTING** document.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.

--- a/coreModulePackages/cookie/package.json
+++ b/coreModulePackages/cookie/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:Adobe-Marketing-Cloud/reactor-turbine.git"
+    "url": "git@github.com:adobe/reactor-turbine.git"
   },
   "dependencies": {
     "js-cookie": "2.1.4"

--- a/coreModulePackages/document/package.json
+++ b/coreModulePackages/document/package.json
@@ -10,6 +10,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:Adobe-Marketing-Cloud/reactor-turbine.git"
+    "url": "git@github.com:adobe/reactor-turbine.git"
   }
 }

--- a/coreModulePackages/loadScript/package.json
+++ b/coreModulePackages/loadScript/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:Adobe-Marketing-Cloud/reactor-turbine.git"
+    "url": "git@github.com:adobe/reactor-turbine.git"
   },
   "dependencies": {
     "@adobe/reactor-promise": "*"

--- a/coreModulePackages/objectAssign/package.json
+++ b/coreModulePackages/objectAssign/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:Adobe-Marketing-Cloud/reactor-turbine.git"
+    "url": "git@github.com:adobe/reactor-turbine.git"
   },
   "dependencies": {
     "object-assign": "4.1.1"

--- a/coreModulePackages/promise/package.json
+++ b/coreModulePackages/promise/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:Adobe-Marketing-Cloud/reactor-turbine.git"
+    "url": "git@github.com:adobe/reactor-turbine.git"
   },
   "dependencies": {
     "promise-polyfill": "8.1.3"

--- a/coreModulePackages/query-string/package.json
+++ b/coreModulePackages/query-string/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:Adobe-Marketing-Cloud/reactor-turbine.git"
+    "url": "git@github.com:adobe/reactor-turbine.git"
   },
   "dependencies": {
     "querystring": "0.2.0"

--- a/coreModulePackages/window/package.json
+++ b/coreModulePackages/window/package.json
@@ -10,6 +10,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:Adobe-Marketing-Cloud/reactor-turbine.git"
+    "url": "git@github.com:adobe/reactor-turbine.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:Adobe-Marketing-Cloud/reactor-turbine.git"
+    "url": "git@github.com:adobe/reactor-turbine.git"
   },
   "dependencies": {
     "@adobe/reactor-cookie": "*",


### PR DESCRIPTION
<!-- Copyright 2019 Adobe. All rights reserved.
This file is licensed to you under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License. You may obtain a copy
of the License at http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software distributed under
the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
OF ANY KIND, either express or implied. See the License for the specific language
governing permissions and limitations under the License. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
The package.json file is currently pointed to `Adobe-Marketing-Cloud`, the repository now currently lives at `adobe`.
<!--- Describe your changes in detail -->
## Types of changes

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [✓] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [✓] I have read the **CONTRIBUTING** document.