### PR TITLE
DTM-14142 Fixes issue where event metadata was being overwritten.

### DIFF
--- a/src/__tests__/normalizeSyntheticEvent.test.js
+++ b/src/__tests__/normalizeSyntheticEvent.test.js
@@ -45,6 +45,21 @@ describe('normalizeSyntheticEvent', function() {
     });
   });
 
+  // JIRA-14142
+  it('does not override meta of first normalized event if synthetic event is ' +
+    'normalized multiple times', function() {
+
+    var syntheticEvent = {};
+    var syntheticEventMeta1 = { $rule: { id: "ABC123" }};
+    var syntheticEventMeta2 = { $rule: { id: "ABC456" }};
+    var normalizedSyntheticEvent1 = normalizeSyntheticEvent(syntheticEventMeta1, syntheticEvent);
+    var normalizedSyntheticEvent2 = normalizeSyntheticEvent(syntheticEventMeta2, syntheticEvent);
+
+    expect(normalizedSyntheticEvent1.$rule.id).toEqual("ABC123");
+    expect(normalizedSyntheticEvent2.$rule.id).toEqual("ABC456");
+  });
+
+
   it('overwrites meta even if same properties are provided by extension', function() {
     var syntheticEvent = normalizeSyntheticEvent(mockMeta, {
       $type: 'oh nos',

--- a/src/normalizeSyntheticEvent.js
+++ b/src/normalizeSyntheticEvent.js
@@ -20,8 +20,7 @@ var objectAssign = require('@adobe/reactor-object-assign');
  * @returns {Object}
  */
 module.exports = function(syntheticEventMeta, syntheticEvent) {
-  syntheticEvent = syntheticEvent || {};
-  objectAssign(syntheticEvent, syntheticEventMeta);
+  syntheticEvent = objectAssign({}, syntheticEvent, syntheticEventMeta);
 
   // Remove after some arbitrary time period when we think users have had sufficient chance
   // to move away from event.type


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When a particular event triggers a rule, the `event` object passed to custom code actions contains a $rule property with information like the rule ID. A problem occurs when an event triggers multiple rules and the first rule performs something asynchronously, like loading custom code asynchronously. By the time the custom code for the first rule is executed, event.$rule gets overwritten by rule metadata from the second rule. If an asynchronously loaded custom code on the first rule logs the event.$rule.id, for example, it will log the rule ID of the second rule, which is wrong.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/DTM-14142
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Event metadata should ways be scoped to the rule.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Automated tests. Also tested with a modified Launch library on a website provided by a customer to reproduce the issue: http://staging.digitalbalance.com.au/launchBugReplication/index.html

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.