### PR TITLE
DTM-13830 Notify extensions when debugging is toggled.

### DIFF
--- a/src/__tests__/createDebugController.test.js
+++ b/src/__tests__/createDebugController.test.js
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+var createDebugController = require('../createDebugController');
+
+describe('function returned by createDebugController', function() {
+  var localStorage;
+  var logger;
+
+  beforeEach(function() {
+    localStorage = jasmine.createSpyObj('localStorage', ['getItem', 'setItem']);
+    logger = {
+      outputEnabled: false
+    };
+    debugController = createDebugController(localStorage, logger);
+  });
+
+  it('returns whether debug is enabled', function() {
+    localStorage.getItem.and.returnValue("true");
+    var debugController = createDebugController(localStorage, logger);
+    expect(debugController.getDebugEnabled()).toBe(true);
+    localStorage.getItem.and.returnValue("false");
+    expect(debugController.getDebugEnabled()).toBe(false);
+  });
+
+  it('persists debug changes', function() {
+    var debugController = createDebugController(localStorage, logger);
+    localStorage.getItem.and.returnValue("false");
+    debugController.setDebugEnabled(true);
+    expect(localStorage.setItem).toHaveBeenCalledWith('debug', true);
+    localStorage.getItem.and.returnValue("true");
+    debugController.setDebugEnabled(false);
+    expect(localStorage.setItem).toHaveBeenCalledWith('debug', false);
+  });
+
+  it('calls onDebugChanged callbacks when debugging is toggled', function() {
+    var debugController = createDebugController(localStorage, logger);
+    var callback1 = jasmine.createSpy('callback1');
+
+    debugController.onDebugChanged(callback1);
+    debugController.setDebugEnabled(true);
+    localStorage.getItem.and.returnValue("true");
+    expect(callback1).toHaveBeenCalledWith(true);
+
+    var callback2 = jasmine.createSpy('callback2');
+    debugController.onDebugChanged(callback2);
+    debugController.setDebugEnabled(false);
+    localStorage.getItem.and.returnValue("false");
+    expect(callback1).toHaveBeenCalledWith(false);
+    expect(callback2).toHaveBeenCalledWith(false);
+    expect (callback1).toHaveBeenCalledTimes(2);
+    expect (callback2).toHaveBeenCalledTimes(1);
+
+    // Shouldn't call the callbacks again since debug
+    // hasn't actually changed.
+    debugController.setDebugEnabled(false);
+    expect (callback1).toHaveBeenCalledTimes(2);
+    expect (callback2).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/hydrateModuleProvider.test.js
+++ b/src/__tests__/hydrateModuleProvider.test.js
@@ -19,6 +19,7 @@ describe('hydrateModuleProvider', function() {
   var moduleProvider;
   var replaceTokens;
   var getDataElementValue;
+  var debugController;
 
   beforeEach(function() {
     container = {
@@ -48,6 +49,10 @@ describe('hydrateModuleProvider', function() {
 
     replaceTokens = function() {};
     getDataElementValue = function() {};
+    debugController = jasmine.createSpyObj('debugController', {
+      onDebugChanged: undefined,
+      getDebugEnabled: true
+    });
   });
 
   it('registers all modules', function() {
@@ -72,7 +77,7 @@ describe('hydrateModuleProvider', function() {
       }
     };
 
-    hydrateModuleProvider(container, moduleProvider);
+    hydrateModuleProvider(container, moduleProvider, debugController);
 
     expect(moduleProvider.registerModule).toHaveBeenCalledWith(
       'ext-a/a1.js',
@@ -110,7 +115,7 @@ describe('hydrateModuleProvider', function() {
   it('hydrates module cache', function() {
     var hydrateModuleProvider = injectHydrateModuleProvider();
 
-    hydrateModuleProvider(container, moduleProvider);
+    hydrateModuleProvider(container, moduleProvider, debugController);
 
     expect(moduleProvider.hydrateCache).toHaveBeenCalled();
   });
@@ -133,7 +138,7 @@ describe('hydrateModuleProvider', function() {
         './createPublicRequire': createPublicRequire
       });
 
-      hydrateModuleProvider(container, moduleProvider);
+      hydrateModuleProvider(container, moduleProvider, debugController);
     });
 
     it('is the publicRequire returned from createPublicRequire', function() {
@@ -186,7 +191,13 @@ describe('hydrateModuleProvider', function() {
         './logger': logger
       });
 
-      hydrateModuleProvider(container, moduleProvider, replaceTokens, getDataElementValue);
+      hydrateModuleProvider(
+        container,
+        moduleProvider,
+        debugController,
+        replaceTokens,
+        getDataElementValue
+      );
       turbine = moduleProvider.registerModule.calls.mostRecent().args[4];
     });
 
@@ -233,6 +244,16 @@ describe('hydrateModuleProvider', function() {
 
     it('contains replaceTokens', function() {
       expect(turbine.replaceTokens).toBe(replaceTokens);
+    });
+
+    it('contains onDebugChanged', function() {
+      expect(turbine.onDebugChanged).toBe(debugController.onDebugChanged);
+    });
+
+    it('contains debugEnabled', function() {
+      expect(turbine.debugEnabled).toBe(true);
+      expect(debugController.getDebugEnabled.and.returnValue(false));
+      expect(turbine.debugEnabled).toBe(false);
     });
   });
 });

--- a/src/__tests__/hydrateSatelliteObject.test.js
+++ b/src/__tests__/hydrateSatelliteObject.test.js
@@ -83,12 +83,12 @@ describe('hydrateSatelliteObject', function() {
   });
 
   it('should add setDebug function on _satellite', function() {
-    var setDebugOutputEnabledSpy = jasmine.createSpy('setDebugOutputEnabled');
+    var setDebugEnabledSpy = jasmine.createSpy('setDebugEnabled');
     var hydrateSatelliteObject = injectHydrateSatelliteObject();
-    hydrateSatelliteObject(_satellite, container, setDebugOutputEnabledSpy);
+    hydrateSatelliteObject(_satellite, container, setDebugEnabledSpy);
     _satellite.setDebug(true);
 
-    expect(setDebugOutputEnabledSpy).toHaveBeenCalledWith(true);
+    expect(setDebugEnabledSpy).toHaveBeenCalledWith(true);
   });
 
   it('successfully allows setting, reading, and removing a cookie', function() {

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -156,6 +156,32 @@ describe('index', function() {
     );
   });
 
+  it('creates namespaced storage', function() {
+    var getNamespacedStorage = jasmine.createSpy().and.returnValue({
+      getItem: function() {}
+    });
+    injectIndex({
+      './getNamespacedStorage': getNamespacedStorage,
+    });
+
+    expect(getNamespacedStorage).toHaveBeenCalledWith(
+      'localStorage'
+    );
+  });
+
+  it('creates namespaced storage', function() {
+    var getNamespacedStorage = jasmine.createSpy().and.returnValue({
+      getItem: function() {}
+    });
+    injectIndex({
+      './getNamespacedStorage': getNamespacedStorage,
+    });
+
+    expect(getNamespacedStorage).toHaveBeenCalledWith(
+      'localStorage'
+    );
+  });
+
   it('sets logger output enabled when local storage item is \'true\'', function() {
     var logger = {};
     window.localStorage.setItem('com.adobe.reactor.debug', true);
@@ -202,12 +228,14 @@ describe('index', function() {
   it('hydrates module provider', function() {
     var container = window._satellite.container;
     var hydrateModuleProvider = jasmine.createSpy();
-    var moduleProvider = {};
+    var moduleProvider = { type: 'moduleProvider' };
+    var debugController = { type: 'debugController' };
     var replaceTokens = function() {};
     var getDataElementValue = function() {};
     injectIndex({
       './hydrateModuleProvider': hydrateModuleProvider,
       './createModuleProvider': function() { return moduleProvider; },
+      './createDebugController': function() { return debugController; },
       './createReplaceTokens': function() { return replaceTokens; },
       './createGetDataElementValue': function() { return getDataElementValue; }
     });
@@ -215,6 +243,7 @@ describe('index', function() {
     expect(hydrateModuleProvider).toHaveBeenCalledWith(
       container,
       moduleProvider,
+      debugController,
       replaceTokens,
       getDataElementValue
     );

--- a/src/createDebugController.js
+++ b/src/createDebugController.js
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+var DEBUG_LOCAL_STORAGE_NAME = 'debug';
+
+module.exports = function(localStorage, logger) {
+  var getPersistedDebugEnabled = function() {
+    return localStorage.getItem(DEBUG_LOCAL_STORAGE_NAME) === 'true';
+  };
+
+  var setPersistedDebugEnabled = function(enabled) {
+    localStorage.setItem(DEBUG_LOCAL_STORAGE_NAME, enabled);
+  };
+
+  var debugChangedCallbacks = [];
+  var onDebugChanged = function(callback) {
+    debugChangedCallbacks.push(callback);
+  };
+
+  logger.outputEnabled = getPersistedDebugEnabled();
+
+  return {
+    onDebugChanged: onDebugChanged,
+    getDebugEnabled: getPersistedDebugEnabled,
+    setDebugEnabled: function(enabled) {
+      if (getPersistedDebugEnabled() !== enabled) {
+        setPersistedDebugEnabled(enabled);
+        logger.outputEnabled = enabled;
+        debugChangedCallbacks.forEach(function(callback) {
+          callback(enabled);
+        });
+      }
+    }
+  };
+};

--- a/src/hydrateModuleProvider.js
+++ b/src/hydrateModuleProvider.js
@@ -17,7 +17,13 @@ var logger = require('./logger');
 var resolveRelativePath = require('./resolveRelativePath');
 var createPublicRequire = require('./createPublicRequire');
 
-module.exports = function(container, moduleProvider, replaceTokens, getDataElementValue) {
+module.exports = function(
+  container,
+  moduleProvider,
+  debugController,
+  replaceTokens,
+  getDataElementValue
+) {
   var extensions = container.extensions;
   var buildInfo = container.buildInfo;
   var propertySettings = container.property.settings;
@@ -43,7 +49,11 @@ module.exports = function(container, moduleProvider, replaceTokens, getDataEleme
           getSharedModule: getSharedModuleExports,
           logger: prefixedLogger,
           propertySettings: propertySettings,
-          replaceTokens: replaceTokens
+          replaceTokens: replaceTokens,
+          onDebugChanged: debugController.onDebugChanged,
+          get debugEnabled() {
+            return debugController.getDebugEnabled();
+          }
         };
 
         Object.keys(extension.modules).forEach(function(referencePath) {

--- a/src/hydrateSatelliteObject.js
+++ b/src/hydrateSatelliteObject.js
@@ -13,7 +13,7 @@
 var cookie = require('@adobe/reactor-cookie');
 var logger = require('./logger');
 
-module.exports = function(_satellite, container, setDebugOutputEnabled, getVar, setCustomVar) {
+module.exports = function(_satellite, container, setDebugEnabled, getVar, setCustomVar) {
   var customScriptPrefixedLogger = logger.createPrefixedLogger('Custom Script');
 
   // Will get replaced by the directCall event delegate from the Core extension. Exists here in
@@ -120,7 +120,7 @@ module.exports = function(_satellite, container, setDebugOutputEnabled, getVar, 
   // to be thrown. This method existed before Reactor.
   _satellite.pageBottom = function() {};
 
-  _satellite.setDebug = setDebugOutputEnabled;
+  _satellite.setDebug = setDebugEnabled;
 
   var warningLogged = false;
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,9 +21,7 @@ var logger = require('./logger');
 var initRules = require('./initRules');
 var dataElementSafe = require('./dataElementSafe');
 var getNamespacedStorage = require('./getNamespacedStorage');
-
-var DEBUG_LOCAL_STORAGE_NAME = 'debug';
-
+var createDebugController = require("./createDebugController");
 
 var _satellite = window._satellite;
 
@@ -94,17 +92,7 @@ if (_satellite && !window.__satelliteLoaded) {
   );
 
   var localStorage = getNamespacedStorage('localStorage');
-
-  var getDebugOutputEnabled = function() {
-    return localStorage.getItem(DEBUG_LOCAL_STORAGE_NAME) === 'true';
-  };
-
-  var setDebugOutputEnabled = function(value) {
-    localStorage.setItem(DEBUG_LOCAL_STORAGE_NAME, value);
-    logger.outputEnabled = value;
-  };
-
-  logger.outputEnabled = getDebugOutputEnabled();
+  var debugController = createDebugController(localStorage, logger);
 
   // Important to hydrate satellite object before we hydrate the module provider or init rules.
   // When we hydrate module provider, we also execute extension code which may be
@@ -112,7 +100,7 @@ if (_satellite && !window.__satelliteLoaded) {
   hydrateSatelliteObject(
     _satellite,
     container,
-    setDebugOutputEnabled,
+    debugController.setDebugEnabled,
     getVar,
     setCustomVar
   );
@@ -120,6 +108,7 @@ if (_satellite && !window.__satelliteLoaded) {
   hydrateModuleProvider(
     container,
     moduleProvider,
+    debugController,
     replaceTokens,
     getDataElementValue
   );


### PR DESCRIPTION
## Description
Alloy (the library, not the extension) has a debugEnabled configuration option that, when true, enables not only logging but some other debugging features, like synchronous validation of data against schema on the backend. From the Alloy extension, we would like to toggle debugEnabled in Alloy when Launch's debugging gets toggled, but there's no way currently for the extension to know when debugging gets toggled in Launch.

This PR adds two properties to the `turbine` free variable:

`onDebugChanged`: Can be passed a callback function. When Launch debugging is toggled, the callback will be called.
`debugEnabled`: A boolean indicating whether Launch debugging is enabled.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/DTM-13830
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See description
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual and automated testing.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] *I will!* I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
