### PR TITLE
Read timeout from delegate definition.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-turbine",
-  "version": "26.0.0",
+  "version": "26.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-turbine",
-  "version": "26.0.0",
+  "version": "26.0.1",
   "description": "Launch rule engine which processes rules on client websites and delegates logic to extensions.",
   "license": "Apache-2.0",
   "scripts": {

--- a/src/rules/__tests__/createAddActionToQueue.test.js
+++ b/src/rules/__tests__/createAddActionToQueue.test.js
@@ -108,7 +108,7 @@ describe('createAddActionToQueue returns a function that when called', function 
       normalizeRuleComponentError,
       logActionError
     )(
-      { modulePath: 'action1', settings: { timeout: 10 } },
+      { modulePath: 'action1', timeout: 10, settings: {} },
       rule,
       event,
       lastPromiseInQueue

--- a/src/rules/__tests__/createAddConditionToQueue.test.js
+++ b/src/rules/__tests__/createAddConditionToQueue.test.js
@@ -172,7 +172,7 @@ describe('createAddRuleToQueue returns a function that when called', function ()
     var logConditionError = emptyFn;
     var logConditionNotMet = emptyFn;
     var lastPromiseInQueue = Promise.resolve();
-    var condition = { modulePath: 'condition1', settings: { timeout: 10 } };
+    var condition = { modulePath: 'condition1', timeout: 10, settings: {} };
 
     return createAddConditionToQueue(
       executeDelegateModule,

--- a/src/rules/createAddActionToQueue.js
+++ b/src/rules/createAddActionToQueue.js
@@ -22,7 +22,7 @@ module.exports = function (
       var timeoutId;
 
       return new Promise(function (resolve, reject) {
-        var promiseTimeout = action.settings.timeout;
+        var promiseTimeout = action.timeout;
 
         var moduleResult = executeDelegateModule(action, syntheticEvent, [
           syntheticEvent

--- a/src/rules/createAddConditionToQueue.js
+++ b/src/rules/createAddConditionToQueue.js
@@ -24,7 +24,7 @@ module.exports = function (
       var timeoutId;
 
       return new Promise(function (resolve, reject) {
-        var promiseTimeout = condition.settings.timeout;
+        var promiseTimeout = condition.timeout;
 
         timeoutId = setTimeout(function () {
           // Reject instead of resolve to prevent subsequent


### PR DESCRIPTION
## Description

In the initial PR we were reading the condition and action timeout from the delegate settings. Forge will emit that directly on the delegate and not inside the settings.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
