### PR TITLE
Added getSharedModule to turbine free variable.

### DIFF
--- a/src/__tests__/createBuildScopedUtilitiesForExtension.test.js
+++ b/src/__tests__/createBuildScopedUtilitiesForExtension.test.js
@@ -55,11 +55,14 @@ describe('createBuildScopedUtilitiesForExtension returns a function that when ca
       .createSpy()
       .and.returnValue(getHostedLibFileUrl);
 
+    var getSharedModule = function () {};
+
     var buildScopedUtilitiesForExtension = createBuildScopedUtilitiesForExtensionTest(
       container,
       createPrefixedLogger,
       createGetExtensionSettings,
       createGetHostedLibFileUrl,
+      getSharedModule,
       replaceTokens,
       getDataElementValue
     );
@@ -81,6 +84,7 @@ describe('createBuildScopedUtilitiesForExtension returns a function that when ca
       getDataElementValue: getDataElementValue,
       getExtensionSettings: getExtensionSettings,
       getHostedLibFileUrl: getHostedLibFileUrl,
+      getSharedModule: getSharedModule,
       logger: prefixedLogger,
       propertySettings: container.property.settings,
       replaceTokens: replaceTokens

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -213,6 +213,19 @@ describe('index', function () {
     );
   });
 
+  it('creates getSharedModule', function () {
+    var moduleProvider = {
+      registerModules: function () {}
+    };
+    var createGetSharedModule = jasmine.createSpy();
+    injectIndex({
+      './moduleProvider': moduleProvider,
+      './createGetSharedModule': createGetSharedModule
+    }).initialize(container, modules);
+
+    expect(createGetSharedModule).toHaveBeenCalledWith(moduleProvider);
+  });
+
   it('builds scoped utilities for extensions', function () {
     var logger = { createPrefixedLogger: function () {} };
     var createGetExtensionSettings = function () {};
@@ -235,6 +248,7 @@ describe('index', function () {
       logger.createPrefixedLogger,
       createGetExtensionSettings,
       createGetHostedLibFileUrl,
+      jasmine.any(Function),
       jasmine.any(Function),
       jasmine.any(Function)
     );
@@ -266,7 +280,7 @@ describe('index', function () {
       './rules/createInitEventModule': function () {
         return createInitEventModule;
       }
-    }).initialize(container, modules);;
+    }).initialize(container, modules);
 
     expect(initRules).toHaveBeenCalledWith(
       buildRuleExecutionOrder,

--- a/src/createBuildScopedUtilitiesForExtension.js
+++ b/src/createBuildScopedUtilitiesForExtension.js
@@ -15,6 +15,7 @@ module.exports = function (
   createPrefixedLogger,
   createGetExtensionSettings,
   createGetHostedLibFileUrl,
+  getSharedModule,
   replaceTokens,
   getDataElementValue
 ) {
@@ -40,6 +41,7 @@ module.exports = function (
       getDataElementValue: getDataElementValue,
       getExtensionSettings: getExtensionSettings,
       getHostedLibFileUrl: getHostedLibFileUrl,
+      getSharedModule: getSharedModule,
       logger: prefixedLogger,
       propertySettings: propertySettings,
       replaceTokens: replaceTokens

--- a/src/createGetSharedModule.js
+++ b/src/createGetSharedModule.js
@@ -9,30 +9,25 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-var delegateType = require('../enum/delegateType');
 
-module.exports = function (
-  executeDelegateModule,
-  logActionError,
-  logRuleCompleted
-) {
-  return function (rule, syntheticEvent) {
-    var action;
+var delegateType = require('./enum/delegateType');
 
-    if (rule.actions) {
-      for (var i = 0; i < rule.actions.length; i++) {
-        action = rule.actions[i];
-        try {
-          executeDelegateModule(action, delegateType.ACTIONS, syntheticEvent, [
-            syntheticEvent
-          ]);
-        } catch (e) {
-          logActionError(action, rule, e);
-          return;
-        }
-      }
+module.exports = function (moduleProvider) {
+  return function (extensionName, sharedModuleName) {
+    // The turbine.getSharedModule contract states that undefined
+    // will be returned if the shared module doesn't exist.
+    if (
+      moduleProvider.getModuleDefinition(
+        extensionName,
+        delegateType.SHARED,
+        sharedModuleName
+      )
+    ) {
+      return moduleProvider.getModuleExports(
+        extensionName,
+        delegateType.SHARED,
+        sharedModuleName
+      );
     }
-
-    logRuleCompleted(rule);
   };
 };

--- a/src/enum/delegateType.js
+++ b/src/enum/delegateType.js
@@ -9,30 +9,11 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-var delegateType = require('../enum/delegateType');
 
-module.exports = function (
-  executeDelegateModule,
-  logActionError,
-  logRuleCompleted
-) {
-  return function (rule, syntheticEvent) {
-    var action;
-
-    if (rule.actions) {
-      for (var i = 0; i < rule.actions.length; i++) {
-        action = rule.actions[i];
-        try {
-          executeDelegateModule(action, delegateType.ACTIONS, syntheticEvent, [
-            syntheticEvent
-          ]);
-        } catch (e) {
-          logActionError(action, rule, e);
-          return;
-        }
-      }
-    }
-
-    logRuleCompleted(rule);
-  };
+module.exports = {
+  EVENTS: 'events',
+  CONDITIONS: 'conditions',
+  ACTIONS: 'actions',
+  SHARED: 'shared',
+  MAIN: 'main'
 };

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ var getNamespacedStorage = require('./getNamespacedStorage');
 
 var createGetExtensionSettings = require('./createGetExtensionSettings');
 var createGetHostedLibFileUrl = require('./createGetHostedLibFileUrl');
+var createGetSharedModule = require('./createGetSharedModule');
 var createBuildScopedUtilitiesForExtension = require('./createBuildScopedUtilitiesForExtension');
 var buildScopedUtilitiesForExtensions = require('./buildScopedUtilitiesForExtensions');
 var hydrateSatelliteObject = require('./hydrateSatelliteObject');
@@ -127,11 +128,14 @@ var initialize = function (container, modules) {
     setCustomVar
   );
 
+  var getSharedModule = createGetSharedModule(moduleProvider);
+
   var buildScopedUtilitiesForExtension = createBuildScopedUtilitiesForExtension(
     container,
     logger.createPrefixedLogger,
     createGetExtensionSettings,
     createGetHostedLibFileUrl,
+    getSharedModule,
     replaceTokens,
     getDataElementValue
   );

--- a/src/rules/__tests__/createAddConditionToQueue.test.js
+++ b/src/rules/__tests__/createAddConditionToQueue.test.js
@@ -41,9 +41,12 @@ describe('createAddRuleToQueue returns a function that when called', function ()
       logConditionError,
       logConditionNotMet
     )(condition, rule, event, lastPromiseInQueue).then(function () {
-      expect(executeDelegateModuleSpy).toHaveBeenCalledWith(condition, 'conditions', event, [
-        event
-      ]);
+      expect(executeDelegateModuleSpy).toHaveBeenCalledWith(
+        condition,
+        'conditions',
+        event,
+        [event]
+      );
     });
   });
 

--- a/src/rules/createAddActionToQueue.js
+++ b/src/rules/createAddActionToQueue.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 
 var Promise = require('@adobe/reactor-promise');
+var delegateType = require('../enum/delegateType');
 
 module.exports = function (
   executeDelegateModule,
@@ -26,7 +27,7 @@ module.exports = function (
 
         var moduleResult = executeDelegateModule(
           action,
-          'actions',
+          delegateType.ACTIONS,
           syntheticEvent,
           [syntheticEvent]
         );

--- a/src/rules/createAddConditionToQueue.js
+++ b/src/rules/createAddConditionToQueue.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 
 var Promise = require('@adobe/reactor-promise');
+var delegateType = require('../enum/delegateType');
 
 module.exports = function (
   executeDelegateModule,
@@ -39,9 +40,12 @@ module.exports = function (
         }, promiseTimeout);
 
         Promise.resolve(
-          executeDelegateModule(condition, 'conditions', syntheticEvent, [
-            syntheticEvent
-          ])
+          executeDelegateModule(
+            condition,
+            delegateType.CONDITIONS,
+            syntheticEvent,
+            [syntheticEvent]
+          )
         ).then(resolve, reject);
       })
         .catch(function (e) {

--- a/src/rules/createEvaluateConditions.js
+++ b/src/rules/createEvaluateConditions.js
@@ -9,6 +9,7 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
+var delegateType = require('../enum/delegateType');
 
 module.exports = function (
   executeDelegateModule,
@@ -26,7 +27,7 @@ module.exports = function (
         try {
           var result = executeDelegateModule(
             condition,
-            'conditions',
+            delegateType.CONDITIONS,
             syntheticEvent,
             [syntheticEvent]
           );

--- a/src/rules/createInitEventModule.js
+++ b/src/rules/createInitEventModule.js
@@ -9,6 +9,7 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
+var delegateType = require('../enum/delegateType');
 
 module.exports = function (
   triggerRule,
@@ -51,7 +52,9 @@ module.exports = function (
         });
       };
 
-      executeDelegateModule(event, 'events', null, [wrappedTriggerRule]);
+      executeDelegateModule(event, delegateType.EVENTS, null, [
+        wrappedTriggerRule
+      ]);
     } catch (e) {
       logger.error(getErrorMessage(event, rule, e));
     }


### PR DESCRIPTION
## Description
Added getSharedModule to turbine free variable. Here's the [associated Furnace PR](https://git.corp.adobe.com/reactor/furnace/pull/2) that removes the get-shared-module babel plugin.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Simpler code, fewer babel plugins.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Ran a build a tested it. Also, automated tests.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
