### PR TITLE
DTM-15198: only observe the verbatim value of dataElement.defaultValu…

### DIFF
--- a/src/__tests__/createGetDataElementValue.test.js
+++ b/src/__tests__/createGetDataElementValue.test.js
@@ -189,38 +189,6 @@ describe('function returned by createGetDataElementValue', function () {
   });
 
   it(
-    'returns an empty string when undefinedVarsReturnEmpty = true and data element value' +
-      'is undefined',
-    function () {
-      var createGetDataElementValue = getInjectedCreateGetDataElementValue({
-        './cleanText': function (value) {
-          return 'cleaned:' + value;
-        }
-      });
-      var moduleProvider = {
-        getModuleExports: function () {
-          return function () {};
-        }
-      };
-      var getDataElementDefinition = function () {
-        return {
-          settings: {}
-        };
-      };
-      var undefinedVarsReturnEmpty = true;
-      var getDataElementValue = createGetDataElementValue(
-        moduleProvider,
-        getDataElementDefinition,
-        replaceTokens,
-        undefinedVarsReturnEmpty
-      );
-      var value = getDataElementValue('testDataElement');
-
-      expect(value).toBe('');
-    }
-  );
-
-  it(
     'returns null when undefinedVarsReturnEmpty = false and data element ' +
       'does not exist',
     function () {
@@ -236,7 +204,7 @@ describe('function returned by createGetDataElementValue', function () {
       );
       var value = getDataElementValue('testDataElement');
 
-      expect(value).toBe(null);
+      expect(value).toBe(undefined);
     }
   );
 
@@ -337,7 +305,46 @@ describe('function returned by createGetDataElementValue', function () {
     });
 
     it(
-      'returns an empty string if value is ' +
+      'returns ' +
+        dataElementValue +
+        ' when undefinedVarsReturnEmpty = true and data element value' +
+        'is ' +
+        dataElementValue,
+      function () {
+        var createGetDataElementValue = getInjectedCreateGetDataElementValue({
+          './cleanText': function (value) {
+            return 'cleaned:' + value;
+          }
+        });
+        var moduleProvider = {
+          getModuleExports: function () {
+            return function () {
+              return dataElementValue;
+            };
+          }
+        };
+        var getDataElementDefinition = function () {
+          return {
+            settings: {}
+          };
+        };
+        var undefinedVarsReturnEmpty = true;
+        var getDataElementValue = createGetDataElementValue(
+          moduleProvider,
+          getDataElementDefinition,
+          replaceTokens,
+          undefinedVarsReturnEmpty
+        );
+        var value = getDataElementValue('testDataElement');
+
+        expect(value).toBe(dataElementValue);
+      }
+    );
+
+    it(
+      'returns ' +
+        dataElementValue +
+        ' if value is ' +
         dataElementValue +
         ' and default is undefined',
       function () {
@@ -363,7 +370,40 @@ describe('function returned by createGetDataElementValue', function () {
         );
         var value = getDataElementValue('testDataElement');
 
-        expect(value).toBe('');
+        expect(value).toBe(dataElementValue);
+      }
+    );
+
+    it(
+      'returns the defaultValue ' +
+        ' if value is ' +
+        dataElementValue +
+        ' and default is defined',
+      function () {
+        var createGetDataElementValue = getInjectedCreateGetDataElementValue();
+        var moduleProvider = {
+          getModuleExports: function () {
+            return function () {
+              return dataElementValue;
+            };
+          }
+        };
+        var getDataElementDefinition = function () {
+          return {
+            settings: {},
+            defaultValue: 'defaultValue'
+          };
+        };
+        var undefinedVarsReturnEmpty = false;
+        var getDataElementValue = createGetDataElementValue(
+          moduleProvider,
+          getDataElementDefinition,
+          replaceTokens,
+          undefinedVarsReturnEmpty
+        );
+        var value = getDataElementValue('testDataElement');
+
+        expect(value).toBe('defaultValue');
       }
     );
   });
@@ -433,9 +473,7 @@ describe('function returned by createGetDataElementValue', function () {
     var createGetDataElementValue = getInjectedCreateGetDataElementValue();
     var moduleProvider = {
       getModuleExports: function () {
-        return function () {
-          return;
-        };
+        return function () {};
       }
     };
     var getDataElementDefinition = function () {

--- a/src/__tests__/createGetDataElementValue.test.js
+++ b/src/__tests__/createGetDataElementValue.test.js
@@ -189,7 +189,7 @@ describe('function returned by createGetDataElementValue', function () {
   });
 
   it(
-    'returns null when undefinedVarsReturnEmpty = false and data element ' +
+    'returns undefined when undefinedVarsReturnEmpty = false and data element ' +
       'does not exist',
     function () {
       var createGetDataElementValue = getInjectedCreateGetDataElementValue();

--- a/src/createGetDataElementValue.js
+++ b/src/createGetDataElementValue.js
@@ -31,10 +31,6 @@ var getErrorMessage = function (
   );
 };
 
-var isDataElementValuePresent = function (value) {
-  return value !== undefined && value !== null;
-};
-
 module.exports = function (
   moduleProvider,
   getDataElementDefinition,
@@ -45,7 +41,7 @@ module.exports = function (
     var dataDef = getDataElementDefinition(name);
 
     if (!dataDef) {
-      return undefinedVarsReturnEmpty ? '' : null;
+      return undefinedVarsReturnEmpty ? '' : undefined;
     }
 
     var storageDuration = dataDef.storageDuration;
@@ -78,15 +74,15 @@ module.exports = function (
     }
 
     if (storageDuration) {
-      if (isDataElementValuePresent(value)) {
+      if (value != null) {
         dataElementSafe.setValue(name, storageDuration, value);
       } else {
         value = dataElementSafe.getValue(name, storageDuration);
       }
     }
 
-    if (!isDataElementValuePresent(value)) {
-      value = dataDef.defaultValue || '';
+    if (value == null && dataDef.defaultValue != null) {
+      value = dataDef.defaultValue;
     }
 
     if (typeof value === 'string') {


### PR DESCRIPTION
## Description

Turbine is replacing missing instances of dataElement value calls with an empty string. This change stops that from happening, and returns `undefined` or `null` where appropriate when the dataElement value does not exist.

## Related Issue

https://jira.corp.adobe.com/browse/DTM-15198

## Motivation and Context

The behavior of assuming that missing values should fall back to an empty string can lead to bugs where the type of the data stored in the dataElement is never considered and can be changed to a string when it shouldn't.

## How Has This Been Tested?

1. A new test was added to ensure that defaultValue is used when it is set and the call to grab the value for a dataElement results in `null` or `undefined`.
2. Tests were altered to ensure the correct falsy value is returned instead of converting the resulting value to an empty string.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

NOTE: we are backfilling all of the previous elements stored in the API that have a `null` value to be empty strings so that turbine continues to behave the same as it does today. However, moving forward calls to retrieve unknown dataElement values will not automatically convert to an empty string upon value retrieval. We view this as both a bug fix and a major change, so we will be publishing a new major version of Turbine.

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
