### PR TITLE
DTM-14947

### DIFF
--- a/src/__tests__/hydrateSatelliteObject.test.js
+++ b/src/__tests__/hydrateSatelliteObject.test.js
@@ -95,7 +95,7 @@ describe('hydrateSatelliteObject', function () {
 
   it('successfully allows setting, reading, and removing a cookie', function () {
     var logger = {
-      warn: jasmine.createSpy(),
+      deprecation: jasmine.createSpy(),
       createPrefixedLogger: function () {}
     };
     var hydrateSatelliteObject = injectHydrateSatelliteObject({
@@ -108,7 +108,7 @@ describe('hydrateSatelliteObject', function () {
 
     _satellite.setCookie(cookieName, cookieValue, 91);
 
-    expect(logger.warn).toHaveBeenCalledWith(
+    expect(logger.deprecation).toHaveBeenCalledWith(
       '_satellite.setCookie is deprecated. Please use ' +
         '_satellite.cookie.set("cookiename", "cookievalue", { expires: 91 }).'
     );
@@ -119,13 +119,13 @@ describe('hydrateSatelliteObject', function () {
 
     expect(_satellite.readCookie(cookieName)).toEqual('cookievalue');
 
-    expect(logger.warn).toHaveBeenCalledWith(
+    expect(logger.deprecation).toHaveBeenCalledWith(
       '_satellite.readCookie is deprecated. Please use _satellite.cookie.get("cookiename").'
     );
 
     _satellite.removeCookie(cookieName);
 
-    expect(logger.warn).toHaveBeenCalledWith(
+    expect(logger.deprecation).toHaveBeenCalledWith(
       '_satellite.removeCookie is deprecated. Please use _satellite.cookie.remove("cookiename").'
     );
 
@@ -167,7 +167,8 @@ describe('hydrateSatelliteObject', function () {
         error: function () {},
         createPrefixedLogger: function () {
           return loggerMock;
-        }
+        },
+        deprecation: function () {}
       }
     });
     hydrateSatelliteObject(_satellite, container);
@@ -187,6 +188,45 @@ describe('hydrateSatelliteObject', function () {
     _satellite.notify('error test', 5);
     expect(loggerMock.error).toHaveBeenCalledWith('error test');
   });
+
+  it(
+    'logger.deprecation is called for all deprecated methods on the ' +
+      '_satellite object',
+    function () {
+      var logger = require('../logger');
+      var deprecationSpy = spyOn(logger, 'deprecation');
+      require('../hydrateSatelliteObject')(
+        _satellite,
+        container,
+        jasmine.createSpy('setDebugEnabled'),
+        jasmine.createSpy('getVar'),
+        jasmine.createSpy('setCustomVar')
+      );
+
+      _satellite.notify('using deprecated function', 1);
+      expect(deprecationSpy).toHaveBeenCalledWith(
+        '_satellite.notify is deprecated. Please use the `_satellite.logger` API.'
+      );
+
+      _satellite.setCookie('cookie name', 'cookie value', 1);
+      expect(deprecationSpy).toHaveBeenCalledWith(
+        '_satellite.setCookie is deprecated. Please use _satellite.cookie.set(' +
+          '"cookie name", "cookie value", { expires: 1 }).'
+      );
+
+      _satellite.readCookie('cookie name');
+      expect(deprecationSpy).toHaveBeenCalledWith(
+        '_satellite.readCookie is deprecated. Please use ' +
+          '_satellite.cookie.get("cookie name").'
+      );
+
+      _satellite.removeCookie('cookie name');
+      expect(deprecationSpy).toHaveBeenCalledWith(
+        '_satellite.removeCookie is deprecated. Please use ' +
+          '_satellite.cookie.remove("cookie name").'
+      );
+    }
+  );
 
   it('exposes a pageBottom method', function () {
     var hydrateSatelliteObject = injectHydrateSatelliteObject();

--- a/src/__tests__/logger.test.js
+++ b/src/__tests__/logger.test.js
@@ -103,4 +103,22 @@ describe('logger', function () {
     logger.outputEnabled = false;
     expect(logger.outputEnabled).toBe(false);
   });
+
+  it('logs deprecations to the console when logger.outputEnabled=true', function () {
+    var message = '_satellite.deprecatedFeature is officially deprecated';
+    logger.outputEnabled = true;
+    logger.deprecation(message);
+
+    expect(window.console.warn).toHaveBeenCalledWith(launchPrefix, message);
+    expect(logger.outputEnabled).toBeTrue();
+  });
+
+  it('logs deprecations to the console when logger.outputEnabled=false', function () {
+    var message = '_satellite.deprecatedFeature is officially deprecated';
+    logger.outputEnabled = false;
+    logger.deprecation(message);
+
+    expect(window.console.warn).toHaveBeenCalledWith(launchPrefix, message);
+    expect(logger.outputEnabled).toBeFalse();
+  });
 });

--- a/src/hydrateSatelliteObject.js
+++ b/src/hydrateSatelliteObject.js
@@ -58,7 +58,7 @@ module.exports = function (
    * 3=info, 4=warn, 5=error, anything else=log
    */
   _satellite.notify = function (message, level) {
-    logger.warn(
+    logger.deprecation(
       '_satellite.notify is deprecated. Please use the `_satellite.logger` API.'
     );
 
@@ -106,7 +106,7 @@ module.exports = function (
       optionsStr +
       ').';
 
-    logger.warn(msg);
+    logger.deprecation(msg);
     cookie.set(name, value, options);
   };
 
@@ -116,7 +116,7 @@ module.exports = function (
    * @returns {string}
    */
   _satellite.readCookie = function (name) {
-    logger.warn(
+    logger.deprecation(
       '_satellite.readCookie is deprecated. ' +
         'Please use _satellite.cookie.get("' +
         name +
@@ -130,7 +130,7 @@ module.exports = function (
    * @param name
    */
   _satellite.removeCookie = function (name) {
-    logger.warn(
+    logger.deprecation(
       '_satellite.removeCookie is deprecated. ' +
         'Please use _satellite.cookie.remove("' +
         name +

--- a/src/logger.js
+++ b/src/logger.js
@@ -101,12 +101,31 @@ var warn = process.bind(null, levels.WARN);
  */
 var error = process.bind(null, levels.ERROR);
 
+/**
+ * Outputs a warning message to the web console.
+ * @param {...*} arg Any argument to be logged.
+ */
+var logDeprecation = function () {
+  var wasEnabled = outputEnabled;
+  outputEnabled = true;
+
+  process.apply(
+    null,
+    Array.prototype.concat(levels.WARN, Array.prototype.slice.call(arguments))
+  );
+
+  if (!wasEnabled) {
+    outputEnabled = false;
+  }
+};
+
 module.exports = {
   log: log,
   info: info,
   debug: debug,
   warn: warn,
   error: error,
+  deprecation: logDeprecation,
   /**
    * Whether logged messages should be output to the console.
    * @type {boolean}

--- a/src/rules/__tests__/normalizeSyntheticEvent.test.js
+++ b/src/rules/__tests__/normalizeSyntheticEvent.test.js
@@ -27,7 +27,7 @@ describe('normalizeSyntheticEvent', function () {
 
   beforeEach(function () {
     logger = {
-      warn: jasmine.createSpy()
+      deprecation: jasmine.createSpy()
     };
 
     normalizeSyntheticEvent = injectNormalizeSyntheticEvent({
@@ -92,7 +92,7 @@ describe('normalizeSyntheticEvent', function () {
     // Note that the type property is non-enumerable, which is why the other tests pass without
     // accounting for the type property.
     expect(syntheticEvent.type).toBe('extension-name.event-name');
-    expect(logger.warn).toHaveBeenCalledWith(
+    expect(logger.deprecation).toHaveBeenCalledWith(
       'Accessing event.type in Adobe Launch has been ' +
         'deprecated and will be removed soon. Please use event.$type instead.'
     );

--- a/src/rules/normalizeSyntheticEvent.js
+++ b/src/rules/normalizeSyntheticEvent.js
@@ -28,7 +28,7 @@ module.exports = function (syntheticEventMeta, syntheticEvent) {
   if (!syntheticEvent.hasOwnProperty('type')) {
     Object.defineProperty(syntheticEvent, 'type', {
       get: function () {
-        logger.warn(
+        logger.deprecation(
           'Accessing event.type in Adobe Launch has been deprecated and will be ' +
             'removed soon. Please use event.$type instead.'
         );


### PR DESCRIPTION
## Description

DTM-14947: Introduce `logger.deprecation`, which logs a warning even if setDebug(true) has not been called.

## Related Issue

[Jira Issue](https://jira.corp.adobe.com/browse/DTM-14947)
[Documentation Change PR](https://git.corp.adobe.com/AdobeDocs/launch.en/pull/236)

## Motivation and Context

We want to be more forceful with showing deprecation warnings even if the customer hasn't turned on _satellite debugging

## How Has This Been Tested?

I introduced a new test that ensures:
- `logger.warn` is called using `logger.deprecation` when `logger.outputEnabled` is true or false
- `logger.deprecation` does not modify the value of `logger.outputEnabled`
- Changed over the deprecated features in turbine from `logger.warn` to `logger.deprecation` and updated tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
