### PR TITLE
Ensure proper rule meta when contextual event data is a plain object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/reactor-turbine",
-  "version": "27.1.1",
+  "version": "27.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/reactor-turbine",
-      "version": "27.1.0",
+      "version": "27.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/reactor-cookie": "*",
@@ -15,7 +15,8 @@
         "@adobe/reactor-object-assign": "*",
         "@adobe/reactor-promise": "*",
         "@adobe/reactor-query-string": "*",
-        "@adobe/reactor-window": "*"
+        "@adobe/reactor-window": "*",
+        "is-plain-object": "^2.0.4"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.0.0",
@@ -47,7 +48,7 @@
         "yargs": "^15.3.1"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=12.13.0"
       }
     },
     "node_modules/@adobe/reactor-cookie": {
@@ -2352,7 +2353,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -4608,7 +4608,6 @@
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "dependencies": {
-        "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
@@ -6308,7 +6307,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
       "dependencies": {
         "isobject": "^3.0.1"
       },
@@ -6401,7 +6399,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6655,7 +6652,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -9723,9 +9719,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.36.1.tgz",
       "integrity": "sha512-eAfqho8dyzuVvrGqpR0ITgEdq0zG2QJeWYh+HeuTbpcaXk8vNFc48B7bJa1xYosTCKx0CuW+447oQOW8HgBIZQ==",
       "dev": true,
-      "dependencies": {
-        "fsevents": "~2.1.2"
-      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -10815,9 +10808,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -11747,10 +11737,8 @@
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dev": true,
       "dependencies": {
-        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.1"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -11834,7 +11822,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -17621,7 +17608,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -17689,8 +17675,7 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "istanbul-instrumenter-loader": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "@adobe/reactor-object-assign": "*",
     "@adobe/reactor-promise": "*",
     "@adobe/reactor-query-string": "*",
-    "@adobe/reactor-window": "*"
+    "@adobe/reactor-window": "*",
+    "is-plain-object": "^2.0.4"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",

--- a/src/rules/__tests__/helpers/CustomEventShim.js
+++ b/src/rules/__tests__/helpers/CustomEventShim.js
@@ -1,0 +1,29 @@
+/***************************************************************************************
+ * (c) 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ ****************************************************************************************/
+
+'use strict';
+
+// source: https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent
+module.exports = function CustomEventShim(event, params) {
+  if (typeof window.CustomEvent === 'function') {
+    return new window.CustomEvent(event, params);
+  }
+
+  params = params || {
+    bubbles: false,
+    cancelable: false,
+    detail: undefined
+  };
+  var evt = document.createEvent('CustomEvent');
+  evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail);
+  return evt;
+};

--- a/src/rules/normalizeSyntheticEvent.js
+++ b/src/rules/normalizeSyntheticEvent.js
@@ -12,6 +12,7 @@
 
 var logger = require('../logger');
 var objectAssign = require('@adobe/reactor-object-assign');
+var isPlainObject = require('is-plain-object');
 
 /**
  * Normalizes a synthetic event so that it exists and has at least meta.
@@ -21,7 +22,16 @@ var objectAssign = require('@adobe/reactor-object-assign');
  */
 module.exports = function (syntheticEventMeta, syntheticEvent) {
   syntheticEvent = syntheticEvent || {};
-  objectAssign(syntheticEvent, syntheticEventMeta);
+
+  // This ensures that as the user hands us a synthetic event for multiple rules,
+  // we aren't overwriting a new meta into the same object reference.
+  if (isPlainObject(syntheticEvent)) {
+    syntheticEvent = objectAssign({}, syntheticEvent, syntheticEventMeta);
+  } else {
+    // When syntheticEvent is not an object, there's nothing we can guarantee
+    // about the ability to "copy". Leave it alone.
+    objectAssign(syntheticEvent, syntheticEventMeta);
+  }
 
   // Remove after some arbitrary time period when we think users have had sufficient chance
   // to move away from event.type


### PR DESCRIPTION
PDCL-5388: Copy syntheticEvent per trigger call when syntheticEvent is a plain object

## Description

When multiple rules are triggered by an event, there was an issue where the meta from Rule B would be present when Rule A is processing.

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-5388
https://jira.corp.adobe.com/browse/PDCL-5144
Closes https://github.com/adobe/reactor-extension-core/issues/35
Closes https://github.com/adobe/reactor-extension-core/pull/36

## How Has This Been Tested?

1. Added a test to ensure that normalizing the same syntheticEvent object with 2 rule meta datas ensures they both contain the correct info
2. Added a test to ensure that when syntheticEvent is not a plain object, we do not try to enhance it

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
