### PR TITLE
PDCL-7898: Fixes cases where using link that start with // was not

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-turbine",
-  "version": "27.2.1-beta.china-cdn.3",
+  "version": "27.2.1",
   "description": "Launch rule engine which processes rules on client websites and delegates logic to extensions.",
   "license": "Apache-2.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-turbine",
-  "version": "27.2.1-beta.china-cdn.1",
+  "version": "27.2.1-beta.china-cdn.2",
   "description": "Launch rule engine which processes rules on client websites and delegates logic to extensions.",
   "license": "Apache-2.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-turbine",
-  "version": "27.2.0",
+  "version": "27.2.1-beta.china-cdn.0",
   "description": "Launch rule engine which processes rules on client websites and delegates logic to extensions.",
   "license": "Apache-2.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-turbine",
-  "version": "27.2.1-beta.china-cdn.0",
+  "version": "27.2.1-beta.china-cdn.1",
   "description": "Launch rule engine which processes rules on client websites and delegates logic to extensions.",
   "license": "Apache-2.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-turbine",
-  "version": "27.2.1-beta.china-cdn.2",
+  "version": "27.2.1-beta.china-cdn.3",
   "description": "Launch rule engine which processes rules on client websites and delegates logic to extensions.",
   "license": "Apache-2.0",
   "scripts": {

--- a/src/__tests__/createDynamicHostResolver.test.js
+++ b/src/__tests__/createDynamicHostResolver.test.js
@@ -160,7 +160,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
 
     describe('handles embed codes that begin with //', function () {
       describe('when isDynamicEnforced=true', function () {
-        it('and is http', function () {
+        it('and the window protocol is http', function () {
           var mockWindow = createMockWindowProtocol('http');
           createDynamicHostResolver = injectCreateDynamicHostResolver({
             '@adobe/reactor-window': mockWindow
@@ -178,7 +178,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
           );
         });
 
-        it('and is https', function () {
+        it('and the window protocol is https', function () {
           turbineEmbedCode = '//assets.adobedtm.com/lib/dev.js';
           dynamicHostResolver = createDynamicHostResolver(
             turbineEmbedCode,
@@ -193,7 +193,41 @@ describe('createDynamicHostResolver returns a function that when called', functi
         });
       });
 
-      it('when isDynamicEnforced=false', function () {});
+      describe('when isDynamicEnforced=false', function () {
+        it('and the window protocol is http', function () {
+          var mockWindow = createMockWindowProtocol('http');
+          createDynamicHostResolver = injectCreateDynamicHostResolver({
+            '@adobe/reactor-window': mockWindow
+          });
+          turbineEmbedCode = '//assets.adobedtm.com/lib/dev.js';
+
+          dynamicHostResolver = createDynamicHostResolver(
+            turbineEmbedCode,
+            undefined, // cdnAllowList,
+            debugController
+          );
+
+          // simple reflection out of the dynamic resolver
+          expect(dynamicHostResolver.decorateWithDynamicHost('/my/url')).toBe(
+            '/my/url'
+          );
+        });
+
+        it('and the window protocol is https', function () {
+          turbineEmbedCode = '//assets.adobedtm.com/lib/dev.js';
+
+          dynamicHostResolver = createDynamicHostResolver(
+            turbineEmbedCode,
+            undefined, // cdnAllowList,
+            debugController
+          );
+
+          // simple reflection out of the dynamic resolver
+          expect(dynamicHostResolver.decorateWithDynamicHost('/my/url')).toBe(
+            '/my/url'
+          );
+        });
+      });
     });
 
     it('creates the resolver silently with a proper turbineEmbedCode', function () {

--- a/src/__tests__/createDynamicHostResolver.test.js
+++ b/src/__tests__/createDynamicHostResolver.test.js
@@ -16,6 +16,7 @@ var createDebugController = require('../createDebugController');
 var loggerSpy = jasmine.createSpy('logger');
 var consoleSpy;
 var turbineEmbedCode;
+var dynamicCdnEnabled;
 var cdnAllowList;
 var dynamicHostResolver;
 
@@ -41,6 +42,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
     debugController = jasmine.createSpyObj('debugController', [
       'onDebugChanged'
     ]);
+    dynamicCdnEnabled = true;
   });
 
   describe('with an undefined cdnAllowList (no decoration should be done)', function () {
@@ -51,6 +53,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
     it('fails silently on creating a URL', function () {
       dynamicHostResolver = createDynamicHostResolver(
         undefined, // turbineEmbedCode
+        dynamicCdnEnabled,
         cdnAllowList,
         debugController
       );
@@ -62,6 +65,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
       turbineEmbedCode = 'https://assets.adobedtm.com/lib/dev.js';
       dynamicHostResolver = createDynamicHostResolver(
         turbineEmbedCode,
+        dynamicCdnEnabled,
         cdnAllowList,
         debugController
       );
@@ -73,6 +77,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
       turbineEmbedCode = 'file://assets.adobedtm.com:8080/lib/dev.js';
       dynamicHostResolver = createDynamicHostResolver(
         turbineEmbedCode,
+        dynamicCdnEnabled,
         cdnAllowList,
         debugController
       );
@@ -83,6 +88,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
     it('reflects back what is sent in when turbineEmbedCode is not resolved', function () {
       dynamicHostResolver = createDynamicHostResolver(
         undefined, // turbineEmbedCode
+        dynamicCdnEnabled,
         cdnAllowList,
         debugController
       );
@@ -96,6 +102,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
       turbineEmbedCode = 'https://assets.adobedtm.com/lib/dev.js';
       dynamicHostResolver = createDynamicHostResolver(
         turbineEmbedCode,
+        dynamicCdnEnabled,
         cdnAllowList,
         debugController
       );
@@ -115,6 +122,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
       expect(function () {
         createDynamicHostResolver(
           undefined, // turbineEmbedCode
+          dynamicCdnEnabled,
           cdnAllowList,
           debugController
         );
@@ -130,6 +138,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
         expect(function () {
           createDynamicHostResolver(
             '//fake.adobeassets.com',
+            dynamicCdnEnabled,
             cdnAllowList,
             debugController
           );
@@ -150,6 +159,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
       expect(function () {
         dynamicHostResolver = createDynamicHostResolver(
           undefined, // turbineEmbedCode
+          dynamicCdnEnabled,
           cdnAllowList,
           debugController
         );
@@ -168,6 +178,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
           turbineEmbedCode = '//assets.adobedtm.com/lib/dev.js';
           dynamicHostResolver = createDynamicHostResolver(
             turbineEmbedCode,
+            dynamicCdnEnabled,
             cdnAllowList,
             debugController
           );
@@ -182,6 +193,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
           turbineEmbedCode = '//assets.adobedtm.com/lib/dev.js';
           dynamicHostResolver = createDynamicHostResolver(
             turbineEmbedCode,
+            dynamicCdnEnabled,
             cdnAllowList,
             debugController
           );
@@ -203,6 +215,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
 
           dynamicHostResolver = createDynamicHostResolver(
             turbineEmbedCode,
+            dynamicCdnEnabled,
             undefined, // cdnAllowList,
             debugController
           );
@@ -218,6 +231,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
 
           dynamicHostResolver = createDynamicHostResolver(
             turbineEmbedCode,
+            dynamicCdnEnabled,
             undefined, // cdnAllowList,
             debugController
           );
@@ -234,6 +248,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
       turbineEmbedCode = 'https://assets.adobedtm.com/lib/dev.js';
       dynamicHostResolver = createDynamicHostResolver(
         turbineEmbedCode,
+        dynamicCdnEnabled,
         cdnAllowList,
         debugController
       );
@@ -245,6 +260,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
       turbineEmbedCode = 'https://assets.adobedtm.com/lib/dev.js';
       dynamicHostResolver = createDynamicHostResolver(
         turbineEmbedCode,
+        dynamicCdnEnabled,
         cdnAllowList,
         debugController
       );
@@ -258,6 +274,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
       turbineEmbedCode = 'https://assets.adobedtm.com/lib/dev.js';
       dynamicHostResolver = createDynamicHostResolver(
         turbineEmbedCode,
+        dynamicCdnEnabled,
         cdnAllowList,
         debugController
       );
@@ -271,6 +288,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
       turbineEmbedCode = 'https://assets.adobedtm.com:8080/lib/dev.js';
       dynamicHostResolver = createDynamicHostResolver(
         turbineEmbedCode,
+        dynamicCdnEnabled,
         cdnAllowList,
         debugController
       );
@@ -284,6 +302,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
       turbineEmbedCode = 'https://assets.adobedtm.com/lib/dev.js';
       dynamicHostResolver = createDynamicHostResolver(
         turbineEmbedCode,
+        dynamicCdnEnabled,
         cdnAllowList,
         debugController
       );
@@ -297,6 +316,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
       turbineEmbedCode = 'http://assets.adobedtm.com/lib/dev.js';
       dynamicHostResolver = createDynamicHostResolver(
         turbineEmbedCode,
+        dynamicCdnEnabled,
         cdnAllowList,
         debugController
       );
@@ -310,6 +330,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
       turbineEmbedCode = 'https://assets.adobedtm.com:8080/lib/dev.js';
       dynamicHostResolver = createDynamicHostResolver(
         turbineEmbedCode,
+        dynamicCdnEnabled,
         cdnAllowList,
         debugController
       );
@@ -323,6 +344,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
       turbineEmbedCode = 'https://assets.adobedtm.com:8080/lib/dev.js';
       dynamicHostResolver = createDynamicHostResolver(
         turbineEmbedCode,
+        dynamicCdnEnabled,
         cdnAllowList,
         debugController
       );
@@ -336,6 +358,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
       turbineEmbedCode = 'https://assets.adobedtm.com:80/lib/dev.js';
       dynamicHostResolver = createDynamicHostResolver(
         turbineEmbedCode,
+        dynamicCdnEnabled,
         cdnAllowList,
         debugController
       );
@@ -349,6 +372,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
       turbineEmbedCode = 'https://assets.adobedtm.com:443/lib/dev.js';
       dynamicHostResolver = createDynamicHostResolver(
         turbineEmbedCode,
+        dynamicCdnEnabled,
         cdnAllowList,
         debugController
       );
@@ -363,6 +387,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
         turbineEmbedCode = 'file://assets.adobedtm.com:8080/lib/dev.js';
         dynamicHostResolver = createDynamicHostResolver(
           turbineEmbedCode,
+          dynamicCdnEnabled,
           cdnAllowList,
           debugController
         );
@@ -380,6 +405,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
         expect(function () {
           createDynamicHostResolver(
             'https://foo-bar-domain.com:443',
+            dynamicCdnEnabled,
             cdnAllowList,
             debugController
           );
@@ -396,6 +422,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
         turbineEmbedCode = 'https://assets.adobedtm.com/lib/dev.js';
         dynamicHostResolver = createDynamicHostResolver(
           turbineEmbedCode,
+          dynamicCdnEnabled,
           cdnAllowList,
           debugController
         );
@@ -441,6 +468,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
       turbineEmbedCode = 'https://assets.adobedtm.com/lib/dev.js';
       createDynamicHostResolver(
         turbineEmbedCode,
+        dynamicCdnEnabled,
         cdnAllowList,
         debugController
       );
@@ -460,6 +488,7 @@ describe('createDynamicHostResolver returns a function that when called', functi
       turbineEmbedCode = 'https://assets.adobedtm.com/lib/dev.js';
       createDynamicHostResolver(
         turbineEmbedCode,
+        dynamicCdnEnabled,
         cdnAllowList,
         debugController
       );

--- a/src/__tests__/createDynamicHostResolver.test.js
+++ b/src/__tests__/createDynamicHostResolver.test.js
@@ -189,20 +189,20 @@ describe('createDynamicHostResolver returns a function that when called', functi
           );
         });
 
-        // it('and the window protocol is https', function () {
-        //   turbineEmbedCode = '//assets.adobedtm.com/lib/dev.js';
-        //   dynamicHostResolver = createDynamicHostResolver(
-        //     turbineEmbedCode,
-        //     dynamicCdnEnabled,
-        //     cdnAllowList,
-        //     debugController
-        //   );
-        //
-        //   expect(consoleSpy).not.toHaveBeenCalled();
-        //   expect(dynamicHostResolver.decorateWithDynamicHost('/my/url')).toBe(
-        //     'https://assets.adobedtm.com/my/url'
-        //   );
-        // });
+        it('and the window protocol is https', function () {
+          turbineEmbedCode = '//assets.adobedtm.com/lib/dev.js';
+          dynamicHostResolver = createDynamicHostResolver(
+            turbineEmbedCode,
+            dynamicCdnEnabled,
+            cdnAllowList,
+            debugController
+          );
+
+          expect(consoleSpy).not.toHaveBeenCalled();
+          expect(dynamicHostResolver.decorateWithDynamicHost('/my/url')).toBe(
+            'https://assets.adobedtm.com/my/url'
+          );
+        });
       });
 
       describe('when isDynamicEnforced=false', function () {

--- a/src/__tests__/createDynamicHostResolver.test.js
+++ b/src/__tests__/createDynamicHostResolver.test.js
@@ -189,20 +189,20 @@ describe('createDynamicHostResolver returns a function that when called', functi
           );
         });
 
-        it('and the window protocol is https', function () {
-          turbineEmbedCode = '//assets.adobedtm.com/lib/dev.js';
-          dynamicHostResolver = createDynamicHostResolver(
-            turbineEmbedCode,
-            dynamicCdnEnabled,
-            cdnAllowList,
-            debugController
-          );
-
-          expect(consoleSpy).not.toHaveBeenCalled();
-          expect(dynamicHostResolver.decorateWithDynamicHost('/my/url')).toBe(
-            'https://assets.adobedtm.com/my/url'
-          );
-        });
+        // it('and the window protocol is https', function () {
+        //   turbineEmbedCode = '//assets.adobedtm.com/lib/dev.js';
+        //   dynamicHostResolver = createDynamicHostResolver(
+        //     turbineEmbedCode,
+        //     dynamicCdnEnabled,
+        //     cdnAllowList,
+        //     debugController
+        //   );
+        //
+        //   expect(consoleSpy).not.toHaveBeenCalled();
+        //   expect(dynamicHostResolver.decorateWithDynamicHost('/my/url')).toBe(
+        //     'https://assets.adobedtm.com/my/url'
+        //   );
+        // });
       });
 
       describe('when isDynamicEnforced=false', function () {

--- a/src/__tests__/createGetHostedLibFileUrl.test.js
+++ b/src/__tests__/createGetHostedLibFileUrl.test.js
@@ -18,6 +18,7 @@ var createDynamicHostResolver = require('../createDynamicHostResolver');
 var dynamicHostResolver = createDynamicHostResolver(
   undefined,
   false,
+  undefined,
   jasmine.createSpyObj('debugController', ['onDebugChanged'])
 );
 

--- a/src/__tests__/createSettingsFileTransformer.test.js
+++ b/src/__tests__/createSettingsFileTransformer.test.js
@@ -13,8 +13,8 @@
 var createSettingsFileTransformer = require('../createSettingsFileTransformer');
 var createDynamicHostResolver = require('../createDynamicHostResolver');
 
-// TODO start here, refactor test calls. pull in tests from createModuleProvider
 var turbineEmbedCode = 'https://assets.adobedtm.com';
+var dynamicCdnEnabled = true;
 var cdnAllowList = ['assets.adobedtm.com'];
 
 var isDynamicEnforced;
@@ -28,6 +28,7 @@ beforeAll(function () {
   ]);
   dynamicHostResolver = createDynamicHostResolver(
     turbineEmbedCode,
+    dynamicCdnEnabled,
     cdnAllowList,
     debugController
   );

--- a/src/__tests__/hydrateModuleProvider.test.js
+++ b/src/__tests__/hydrateModuleProvider.test.js
@@ -63,7 +63,8 @@ describe('hydrateModuleProvider', function () {
 
     decorateWithDynamicHost = createDynamicHostResolver(
       'https://assets.adobedtm.com',
-      ['assets.adobedtm.com'],
+      true, //dynamicCdnEnabled
+      ['assets.adobedtm.com'], //cdnAllowList
       debugControllerSpy
     ).decorateWithDynamicHost;
     settingsFileTransformer = createSettingsFileTransformer(

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -474,7 +474,7 @@ describe('index', function () {
             'Unable to find the Library Embed Code for Dynamic Host Resolution.'
           );
 
-          expect(logger.warn).toHaveBeenCalledWith(
+          expect(logger.warn).toHaveBeenCalledOnceWith(
             'Please review the following error:'
           );
         });
@@ -493,7 +493,7 @@ describe('index', function () {
               'Please contact your CSM for more information.'
           );
 
-          expect(logger.warn).toHaveBeenCalledWith(
+          expect(logger.warn).toHaveBeenCalledOnceWith(
             'Please review the following error:'
           );
         });
@@ -513,7 +513,7 @@ describe('index', function () {
               'Please contact your CSM for more information.'
           );
 
-          expect(logger.warn).toHaveBeenCalledWith(
+          expect(logger.warn).toHaveBeenCalledOnceWith(
             'Please review the following error:'
           );
         });

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -32,6 +32,7 @@ describe('index', function () {
           }
         },
         company: {
+          dynamicCdnEnabled: true,
           cdnAllowList: undefined
         }
       }
@@ -463,59 +464,71 @@ describe('index', function () {
           }
         });
 
-        it('the approved hosts list is empty', function () {
-          window._satellite.container.company.cdnAllowList = [];
+        describe('isDynamicEnforced=true', function () {
+          beforeEach(function () {
+            window._satellite.container.company.isDynamicEnforced = true;
+          });
 
-          expect(function () {
-            injectIndex({
-              './logger': logger
-            });
-          }).toThrowError(
-            'Unable to find the Library Embed Code for Dynamic Host Resolution.'
-          );
+          it('and the approved hosts list is empty', function () {
+            window._satellite.container.company.cdnAllowList = [];
 
-          expect(logger.warn).toHaveBeenCalledOnceWith(
-            'Please review the following error:'
-          );
+            expect(function () {
+              injectIndex({
+                './logger': logger
+              });
+            }).toThrowError(
+              'Unable to find the Library Embed Code for Dynamic Host Resolution.'
+            );
+
+            expect(logger.warn).toHaveBeenCalledOnceWith(
+              'Please review the following error:'
+            );
+          });
         });
       });
 
       describe('there is a proper turbineEmbedCode', function () {
-        it('the approved hosts list is empty', function () {
-          window._satellite.container.company.cdnAllowList = [];
+        describe('isDynamicEnforced=true', function () {
+          beforeEach(function () {
+            window._satellite.container.company.isDynamicEnforced = true;
+          });
 
-          expect(function () {
-            injectIndex({
-              './logger': logger
-            });
-          }).toThrowError(
-            'This library is not authorized for this domain. ' +
-              'Please contact your CSM for more information.'
-          );
+          it('and the approved hosts list is empty', function () {
+            window._satellite.container.company.cdnAllowList = [];
 
-          expect(logger.warn).toHaveBeenCalledOnceWith(
-            'Please review the following error:'
-          );
-        });
+            expect(function () {
+              injectIndex({
+                './logger': logger
+              });
+            }).toThrowError(
+              'This library is not authorized for this domain. ' +
+                'Please contact your CSM for more information.'
+            );
 
-        it('the turbine embed code is not in the list of approved hosts', function () {
-          window._satellite.container.company.cdnAllowList = [
-            'first.domain.com',
-            'second.domain.com'
-          ];
+            expect(logger.warn).toHaveBeenCalledOnceWith(
+              'Please review the following error:'
+            );
+          });
 
-          expect(function () {
-            injectIndex({
-              './logger': logger
-            });
-          }).toThrowError(
-            'This library is not authorized for this domain. ' +
-              'Please contact your CSM for more information.'
-          );
+          it('and the turbine embed code is not in the list of approved hosts', function () {
+            window._satellite.container.company.cdnAllowList = [
+              'first.domain.com',
+              'second.domain.com'
+            ];
 
-          expect(logger.warn).toHaveBeenCalledOnceWith(
-            'Please review the following error:'
-          );
+            expect(function () {
+              injectIndex({
+                './logger': logger
+              });
+            }).toThrowError(
+              'This library is not authorized for this domain. ' +
+                'Please contact your CSM for more information.'
+            );
+
+            expect(logger.warn).toHaveBeenCalledOnceWith(
+              'Please review the following error:'
+            );
+          });
         });
       });
     });

--- a/src/createDynamicHostResolver.js
+++ b/src/createDynamicHostResolver.js
@@ -13,32 +13,52 @@
 var window = require('@adobe/reactor-window');
 
 module.exports = function (turbineEmbedCode, cdnAllowList, debugController) {
+  // A missing list means that we are not trying to dynamic replace (archives,
+  // sftp, no premium CDN option enabled on the company).
   // even an empty list is flagging to us that we're trying to enforce dynamic
   var isDynamicEnforced = Array.isArray(cdnAllowList);
   var shouldAugment = Boolean(isDynamicEnforced && turbineEmbedCode);
 
-  // TODO: web only? I think embedded TVs wouldn't have
-  //  __satellite.container.dynamicEnforced turned on
+  // using document.createElement('a') because IE10/11 doesn't support new URL()
   var turbineUrl = document.createElement('a');
-  turbineUrl.href = turbineEmbedCode;
-  if (
-    (!/^https?:\/\/.*/.test(turbineEmbedCode) || !turbineUrl.host) &&
-    isDynamicEnforced
-  ) {
-    var missingEmbedCodeError = new Error(
-      'Unable to find the Library Embed Code for Dynamic Host Resolution.'
-    );
-    missingEmbedCodeError.code = 'dynamic_host_resolver_constructor_error';
-    throw missingEmbedCodeError;
-  }
-
-  if (isDynamicEnforced && cdnAllowList.indexOf(turbineUrl.hostname) === -1) {
-    var dynamicDeniedError = new Error(
-      'This library is not authorized for this domain. ' +
-        'Please contact your CSM for more information.'
-    );
-    dynamicDeniedError.code = 'dynamic_host_not_allowed';
-    throw dynamicDeniedError;
+  if (isDynamicEnforced) {
+    // throw whenever we can't determine the embed code
+    var throwUnavailableEmbedCode = function () {
+      var missingEmbedCodeError = new Error(
+        'Unable to find the Library Embed Code for Dynamic Host Resolution.'
+      );
+      missingEmbedCodeError.code = 'dynamic_host_resolver_constructor_error';
+      throw missingEmbedCodeError;
+    };
+    if (turbineEmbedCode) {
+      var httpsMatcher = new RegExp(/^https?:\/\/.*/);
+      var doubleSlashMatcher = new RegExp(/^\/\/.*/);
+      if (
+        !httpsMatcher.test(turbineEmbedCode) &&
+        !doubleSlashMatcher.test(turbineEmbedCode)
+      ) {
+        throwUnavailableEmbedCode();
+      }
+      // try to construct the url
+      if (!httpsMatcher.test(turbineEmbedCode)) {
+        turbineUrl.href = window.location.protocol + turbineEmbedCode;
+      } else {
+        turbineUrl.href = turbineEmbedCode;
+      }
+    }
+    // check URL construction
+    if (!turbineUrl.host) {
+      throwUnavailableEmbedCode();
+    }
+    // is this within the allowed list of hosts?
+    if (cdnAllowList.indexOf(turbineUrl.hostname) === -1) {
+      var dynamicDeniedError = new Error(
+        'This library is not authorized for this domain. ' +
+          'Please contact your CSM for more information.'
+      );
+      dynamicDeniedError.code = 'dynamic_host_not_allowed';
+      throw dynamicDeniedError;
+    }
   }
 
   /**
@@ -67,7 +87,7 @@ module.exports = function (turbineEmbedCode, cdnAllowList, debugController) {
         sanitizedHost = sanitizedHost.replace(':443/', '');
       }
 
-      memoizedHostResult = 'https://' + sanitizedHost;
+      memoizedHostResult = turbineUrl.protocol + '//' + sanitizedHost;
     } else {
       memoizedHostResult = '';
     }

--- a/src/createDynamicHostResolver.js
+++ b/src/createDynamicHostResolver.js
@@ -12,11 +12,18 @@
 
 var window = require('@adobe/reactor-window');
 
-module.exports = function (turbineEmbedCode, cdnAllowList, debugController) {
+module.exports = function (
+  turbineEmbedCode,
+  dynamicCdnEnabled,
+  cdnAllowList,
+  debugController
+) {
   // A missing list means that we are not trying to dynamic replace (archives,
   // sftp, no premium CDN option enabled on the company).
   // even an empty list is flagging to us that we're trying to enforce dynamic
-  var isDynamicEnforced = Array.isArray(cdnAllowList);
+  var isDynamicEnforced = Boolean(
+    dynamicCdnEnabled && Array.isArray(cdnAllowList)
+  );
   var shouldAugment = Boolean(isDynamicEnforced && turbineEmbedCode);
 
   // using document.createElement('a') because IE10/11 doesn't support new URL()

--- a/src/createDynamicHostResolver.js
+++ b/src/createDynamicHostResolver.js
@@ -38,23 +38,14 @@ module.exports = function (
       throw missingEmbedCodeError;
     };
     if (turbineEmbedCode) {
-      var httpsMatcher = new RegExp(/^https?:\/\/.*/);
-      var doubleSlashMatcher = new RegExp(/^\/\/.*/);
-      if (
-        !httpsMatcher.test(turbineEmbedCode) &&
-        !doubleSlashMatcher.test(turbineEmbedCode)
-      ) {
+      var urlMatcher = /^((https?:)?\/\/).+/;
+      if (!urlMatcher.test(turbineEmbedCode)) {
         throwUnavailableEmbedCode();
       }
-      // try to construct the url
-      if (!httpsMatcher.test(turbineEmbedCode)) {
-        turbineUrl.href = window.location.protocol + turbineEmbedCode;
-      } else {
-        turbineUrl.href = turbineEmbedCode;
-      }
+      turbineUrl.href = turbineEmbedCode;
     }
     // check URL construction
-    if (!turbineUrl.host) {
+    if (!turbineUrl.hostname) {
       throwUnavailableEmbedCode();
     }
     // is this within the allowed list of hosts?

--- a/src/createDynamicHostResolver.js
+++ b/src/createDynamicHostResolver.js
@@ -29,7 +29,6 @@ module.exports = function (
   // using document.createElement('a') because IE10/11 doesn't support new URL()
   var turbineUrl = document.createElement('a');
   if (isDynamicEnforced) {
-    // throw whenever we can't determine the embed code
     var throwUnavailableEmbedCode = function () {
       var missingEmbedCodeError = new Error(
         'Unable to find the Library Embed Code for Dynamic Host Resolution.'
@@ -38,12 +37,17 @@ module.exports = function (
       throw missingEmbedCodeError;
     };
     if (turbineEmbedCode) {
-      var urlMatcher = /^((https?:)?\/\/).+/;
-      if (!urlMatcher.test(turbineEmbedCode)) {
+      if (!/^((https?:)?\/\/).+/.test(turbineEmbedCode)) {
         throwUnavailableEmbedCode();
       }
-      turbineUrl.href = turbineEmbedCode;
+      if (/^\/\/.+/.test(turbineEmbedCode)) {
+        // for IE 10, you must throw on the protocol
+        turbineUrl.href = window.location.protocol + turbineEmbedCode;
+      } else {
+        turbineUrl.href = turbineEmbedCode;
+      }
     }
+
     // check URL construction
     if (!turbineUrl.hostname) {
       throwUnavailableEmbedCode();

--- a/src/index.js
+++ b/src/index.js
@@ -99,6 +99,7 @@ if (_satellite && !window.__satelliteLoaded) {
   try {
     dynamicHostResolver = createDynamicHostResolver(
       currentScriptSource,
+      Boolean(container.company.dynamicCdnEnabled),
       container.company.cdnAllowList,
       debugController
     );


### PR DESCRIPTION
finding the embed code. Stops upgrading to https all the time (respects protocol).

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://jira.corp.adobe.com/browse/PDCL-7898

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

There will be embed codes out there that begin with `//` and we would want them to work without the user having to update the link on their website.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. New unit tests in the project
2. Run against Symphony tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
