### PR TITLE
Remove deprecated querystring dependency.

### DIFF
--- a/coreModulePackages/query-string/.gitignore
+++ b/coreModulePackages/query-string/.gitignore
@@ -1,0 +1,1 @@
+adobe-reactor-query-string-*.tgz

--- a/coreModulePackages/query-string/.npmignore
+++ b/coreModulePackages/query-string/.npmignore
@@ -1,0 +1,2 @@
+test.js
+adobe-reactor-query-string-*.tgz

--- a/coreModulePackages/query-string/index.js
+++ b/coreModulePackages/query-string/index.js
@@ -55,27 +55,31 @@ var parseQueryString = function (query) {
   return result;
 };
 
-var spaceToken = '{{space}}';
+/**
+ * Transform an object into a query string.
+ *
+ * Keys having object values are ignored.
+ *
+ * @param {object} the object to transform into a query string
+ * @returns {string} the parsed query string
+ */
 
-var stringify = function (object) {
+var stringifyObject = function (object) {
+  var spaceToken = '{{space}}';
   var params = new URLSearchParams();
-  object = Object.keys(object).reduce(function (acc, k) {
-    if (typeof object[k] === 'string') {
-      acc[k] = object[k].replace(/ /g, spaceToken);
-    } else if (
-      Array.isArray(object[k]) ||
-      ['boolean', 'number'].includes(typeof object[k])
-    ) {
-      acc[k] = object[k];
-    } else {
-      acc[k] = '';
-    }
-
-    return acc;
-  }, {});
 
   Object.keys(object).forEach(function (key) {
     var value = object[key];
+
+    if (typeof object[key] === 'string') {
+      value = value.replace(/ /g, spaceToken);
+    } else if (
+      ['object', 'undefined'].includes(typeof value) &&
+      !Array.isArray(value)
+    ) {
+      value = '';
+    }
+
     if (Array.isArray(value)) {
       value.forEach(function (arrayValue) {
         params.append(key, arrayValue);
@@ -99,6 +103,6 @@ module.exports = {
     return parseQueryString(string);
   },
   stringify: function (object) {
-    return stringify(object);
+    return stringifyObject(object);
   }
 };

--- a/coreModulePackages/query-string/index.js
+++ b/coreModulePackages/query-string/index.js
@@ -37,14 +37,20 @@ var parseQueryString = function (query) {
   var cleanQuery = query.trim().replace(/^[?#&]/, '');
   var params = new URLSearchParams(cleanQuery);
 
-  params.keys().forEach(function (key) {
-    var values = params.getAll(key);
-    if (values.length === 1) {
-      result[key] = values[0];
-    } else {
-      result[key] = values;
+  var iter = params.keys();
+  do {
+    var v = iter.next();
+    var key = v.value;
+
+    if (key) {
+      var values = params.getAll(key);
+      if (values.length === 1) {
+        result[key] = values[0];
+      } else {
+        result[key] = values;
+      }
     }
-  });
+  } while (v.done === false);
 
   return result;
 };

--- a/coreModulePackages/query-string/index.js
+++ b/coreModulePackages/query-string/index.js
@@ -11,7 +11,78 @@
  ****************************************************************************************/
 'use strict';
 
-var querystring = require('querystring');
+/**
+ * Parse a query string into an object. Leading `?` or `#` are ignored, so you
+ * can pass `location.search` or `location.hash` directly.
+ *
+ * URL components are decoded with decode-uri-component.
+ *
+ * Parse arrays with elements using duplicate keys, e.g. ?a=1&a=2 becomes
+ * {a: ['1', '2']}.
+ *
+ * Query keys are sorted alphabetically.
+ *
+ * Numbers and booleans are NOT parsed; they are left as strings.
+ * @param {string} query the query part of a url
+ * @returns {{ [key: string]: string | string[] | undefined }} the parsed query string
+ */
+var parseQueryString = function (query) {
+  /** @type {{[key: string]: string | string[] | undefined }} */
+  var result = {};
+
+  if (!query || typeof query !== 'string') {
+    return result;
+  }
+
+  var cleanQuery = query.trim().replace(/^[?#&]/, '');
+  var params = new URLSearchParams(cleanQuery);
+
+  params.keys().forEach(function (key) {
+    var values = params.getAll(key);
+    if (values.length === 1) {
+      result[key] = values[0];
+    } else {
+      result[key] = values;
+    }
+  });
+
+  return result;
+};
+
+var spaceToken = '{{space}}';
+
+var stringify = function (object) {
+  var params = new URLSearchParams();
+  object = Object.keys(object).reduce(function (acc, k) {
+    if (typeof object[k] === 'string') {
+      acc[k] = object[k].replace(/ /g, spaceToken);
+    } else if (
+      Array.isArray(object[k]) ||
+      ['boolean', 'number'].includes(typeof object[k])
+    ) {
+      acc[k] = object[k];
+    } else {
+      acc[k] = '';
+    }
+
+    return acc;
+  }, {});
+
+  Object.keys(object).forEach(function (key) {
+    var value = object[key];
+    if (Array.isArray(value)) {
+      value.forEach(function (arrayValue) {
+        params.append(key, arrayValue);
+      });
+    } else {
+      params.append(key, value);
+    }
+  });
+
+  return params
+    .toString()
+    .replace(new RegExp(encodeURIComponent(spaceToken), 'g'), '%20');
+};
 
 // We proxy the underlying querystring module so we can limit the API we expose.
 // This allows us to more easily make changes to the underlying implementation later without
@@ -19,15 +90,9 @@ var querystring = require('querystring');
 // can make adjustments as needed.
 module.exports = {
   parse: function (string) {
-    //
-    if (typeof string === 'string') {
-      // Remove leading ?, #, & for some leniency so you can pass in location.search or
-      // location.hash directly.
-      string = string.trim().replace(/^[?#&]/, '');
-    }
-    return querystring.parse(string);
+    return parseQueryString(string);
   },
   stringify: function (object) {
-    return querystring.stringify(object);
+    return stringify(object);
   }
 };

--- a/coreModulePackages/query-string/package-lock.json
+++ b/coreModulePackages/query-string/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@adobe/reactor-query-string",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
+  "version": "2.0.0",
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+  "packages": {
+    "": {
+      "name": "@adobe/reactor-query-string",
+      "version": "2.0.0",
+      "license": "Apache-2.0"
     }
   }
 }

--- a/coreModulePackages/query-string/package.json
+++ b/coreModulePackages/query-string/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-query-string",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Utility for parsing and serializing URL query strings. Intended for use in Adobe Launch extensions.",
   "license": "Apache-2.0",
   "author": {
@@ -11,8 +11,5 @@
   "repository": {
     "type": "git",
     "url": "git@github.com:adobe/reactor-turbine.git"
-  },
-  "dependencies": {
-    "querystring": "0.2.0"
   }
 }

--- a/coreModulePackages/query-string/test.js
+++ b/coreModulePackages/query-string/test.js
@@ -27,6 +27,19 @@ describe('queryString', function () {
         baz: 'qux'
       });
     });
+
+    it('supports multiple parameters with the same name', function () {
+      expect(queryString.parse('foo=bar&foo=baz')).toEqual({
+        foo: ['bar', 'baz']
+      });
+    });
+
+    it('supports empty query strings', function () {
+      expect(queryString.parse('foo=&bar=')).toEqual({
+        foo: '',
+        bar: ''
+      });
+    });
   });
 
   describe('stringify', function () {
@@ -39,5 +52,43 @@ describe('queryString', function () {
 
   it('does not expose other methods supported by the underlying implementation', function () {
     expect(Object.keys(queryString).length).toBe(2);
+  });
+
+  it('handles objects with array and string', function () {
+    expect(
+      queryString.stringify({
+        foo: 'bar',
+        baz: ['qux', 'quux'],
+        corge: '',
+        n: 5
+      })
+    ).toEqual('foo=bar&baz=qux&baz=quux&corge=&n=5');
+  });
+
+  it('handles objects with strings with spaces', function () {
+    expect(
+      queryString.stringify({
+        foo: 'bar qux zoo'
+      })
+    ).toEqual('foo=bar%20qux%20zoo');
+  });
+
+  it('handles objects with multiple levels', function () {
+    expect(
+      queryString.stringify({
+        foo: 'bar',
+        o: { a: 5 }
+      })
+    ).toEqual('foo=bar&o=');
+  });
+
+  it('handles objects with null or undefined', function () {
+    expect(
+      queryString.stringify({
+        foo: 'bar',
+        o: null,
+        z: undefined
+      })
+    ).toEqual('foo=bar&o=&z=');
   });
 });


### PR DESCRIPTION
## Description

Remove the `querystring` dependency. It is deprecated and no longer maintained.

## Related Issue



## Motivation and Context

`alloy` uses `@adobe/reactor-query-string` as a dependency. We added a custom build script for `alloy`. When we run that script with `npx`, we see a warning saying that `querystring` is deprecated. We want to get rid of that warning. This PR uses [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams). I added a few tests to make sure the change is backward compatible. 

A few of the differences between [querystring](https://www.npmjs.com/package/querystring) and [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) can be found [here](https://vladimirgorej.com/blog/how-to-migrate-from-querystring-to-url-search-params-in-nodejs/).

Even if the changes should be compatible, I will release these as a new major version.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
