### PR TITLE
Add support for modules that were transpilled using BabelJS.

### DIFF
--- a/src/__tests__/extractModuleExports.test.js
+++ b/src/__tests__/extractModuleExports.test.js
@@ -38,4 +38,19 @@ describe('extract module exports', function () {
 
     expect(extractModuleExports(moduleScript)).toEqual(moduleExports);
   });
+
+  it('returns the extracted exports from a transpiled module using babel', function () {
+    var moduleExports = 'exportedvalue';
+
+    var moduleScript = function (module, exports) {
+      Object.defineProperty(exports, '__esModule', {
+        value: true
+      });
+      exports.default = void 0;
+      var _default = moduleExports;
+      exports.default = _default;
+    };
+
+    expect(extractModuleExports(moduleScript)).toEqual(moduleExports);
+  });
 });

--- a/src/extractModuleExports.js
+++ b/src/extractModuleExports.js
@@ -17,5 +17,14 @@ module.exports = function (script, require, turbine) {
 
   script.call(module.exports, module, module.exports, require, turbine);
 
+  if (
+    module &&
+    module.exports &&
+    module.exports.__esModule &&
+    Object.prototype.hasOwnProperty.call(module.exports, 'default')
+  ) {
+    return module.exports.default;
+  }
+
   return module.exports;
 };


### PR DESCRIPTION
## Description

The alloy extension needs to convert their modules to ES6 module. Those modules will be converted to CommonJS using BabelJS. This PR allows Turbine to support those modules.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
